### PR TITLE
Show .8xv files in the File Picker.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ function attachClickListeners() {
 function selectFile() {
   const input = document.createElement('input');
   input.type  = 'file';
-  input.accept = '.8xp,.8xg,.83p,.83g,.82p,.82g';
+  input.accept = '.8xp,.8xg,.83p,.83g,.82p,.82g,.8xv';
   input.addEventListener('change', async c => {
     file = tifiles.parseFile(await readFile(c.target.files[0]));
     console.log(file);

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ function attachClickListeners() {
 function selectFile() {
   const input = document.createElement('input');
   input.type  = 'file';
-  input.accept = '.8xp,.8xg,.83p,.83g,.82p,.82g,.8xv';
+  input.accept = '.8xp,.8xg,.8xv,.83p,.83g,.82p,.82g';
   input.addEventListener('change', async c => {
     file = tifiles.parseFile(await readFile(c.target.files[0]));
     console.log(file);


### PR DESCRIPTION
.8xv files are currently being omitted from the file picker, and quite a bit of programs depend on them. Currently, you have to clear the filter to pick them. It would be more intuitive if you could pick a .8xv file.

--reese